### PR TITLE
Cope with EXDEV directory rename failure in ptk_rename_file

### DIFF
--- a/src/ptk/ptk-file-misc.c
+++ b/src/ptk/ptk-file-misc.c
@@ -3170,7 +3170,7 @@ _move_task:
                     // Respond to an EXDEV error by switching to a move (e.g. aufs
                     // directory rename fails due to the directory existing in
                     // multiple underlying branches)
-                    if ( errno == 18 )
+                    if ( errno == EXDEV )
                         goto _move_task;
 
                     // Unknown error has occurred - alert user as usual

--- a/src/vfs/vfs-file-task.c
+++ b/src/vfs/vfs-file-task.c
@@ -746,7 +746,7 @@ vfs_file_task_do_move ( VFSFileTask* task,
 
     if ( result != 0 )
     {
-        if ( result == -1 && errno == 18 )  //MOD Invalid cross-link device
+        if ( result == -1 && errno == EXDEV )  //MOD Invalid cross-link device
             return 18;
         vfs_file_task_error( task, errno, _("Renaming"), src_file );
         if ( should_abort( task ) )
@@ -823,7 +823,7 @@ vfs_file_task_move( char* src_file, VFSFileTask* task )
         else
         {
             /* g_print("on the same dev: %s\n", src_file); */
-            if ( vfs_file_task_do_move( task, src_file, dest_file ) == 18 )  //MOD
+            if ( vfs_file_task_do_move( task, src_file, dest_file ) == EXDEV )  //MOD
             {
                 //MOD Invalid cross-device link (st_dev not always accurate test)
                 // so now redo move as copy


### PR DESCRIPTION
Fixes 'Invalid cross-device link' when renaming directories on an
aufs volume / https://github.com/BwackNinja/spacefm/issues/35

goto implementation as suggested by IG.
